### PR TITLE
Lint and documentation fixes

### DIFF
--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -175,7 +175,6 @@ def _write_multiple_frames(im: Image.Image, fp: BytesIO, filename: str):
 
         fp.seek(fram_end)
 
-    bmp = im.encoderinfo.get("bitmap_format") == "bmp"
     display_rate = im.encoderinfo.get("display_rate", 2)
     n_frames = len(frames)
     n_steps = len(seq) if seq else n_frames

--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -2,7 +2,6 @@ import struct
 from io import BytesIO
 
 from PIL import BmpImagePlugin, CurImagePlugin, Image, ImageFile
-from PIL._binary import i16le as i16
 from PIL._binary import i32le as i32
 from PIL._binary import o8
 from PIL._binary import o16le as o16

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -137,10 +137,11 @@ class CurFile(IcoImagePlugin.IcoFile):
             icon_header["dim"] = (icon_header["width"], icon_header["height"])
             icon_header["square"] = icon_header["width"] * icon_header["height"]
 
-            # TODO: This needs further investigation. Cursor files do not really specify their bpp
-            # like ICO's as those bits are used for the y_hotspot. For now, bpp is calculated by
-            # subtracting the AND mask (equal to number of pixels * 1bpp) and dividing by the number
-            # of pixels. This seems to work well so far.
+            # TODO: This needs further investigation. Cursor files do not really
+            # specify their bpp like ICO's as those bits are used for the y_hotspot.
+            # For now, bpp is calculated by subtracting the AND mask (equal to number
+            # of pixels * 1bpp) and dividing by the number of pixels.
+            # This seems to work well so far.
             BITMAP_INFO_HEADER_SIZE = 40
             bpp_without_and = (
                 (icon_header["size"] - BITMAP_INFO_HEADER_SIZE) * 8

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -98,7 +98,7 @@ def _accept(prefix):
 ##
 # Image plugin for Windows Cursor files.
 class CurFile(IcoImagePlugin.IcoFile):
-    def __init__(self, buf: BytesIO):
+    def __init__(self, buf: BytesIO()):
         """
         Parse image from file-like object containing cur file data
         """


### PR DESCRIPTION
You will see that the Lint CI job is failing at https://github.com/python-pillow/Pillow/pull/6606.

You will also see that [there is an error when building the documentation.](https://github.com/python-pillow/Pillow/actions/runs/3109827288/jobs/5040877406#step:11:284)
> /opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/PIL/CurImagePlugin.py:docstring of PIL.CurImagePlugin.CurFile:1: WARNING: py:class reference target not found: _io.BytesIO

These are suggestions to resolve that.
