### PR TITLE
Use IcoFile sizes method

### DIFF
--- a/Tests/test_file_ani.py
+++ b/Tests/test_file_ani.py
@@ -7,7 +7,7 @@ import pytest
 from PIL import Image
 
 
-def test_aero_busy():
+def test_aero_busy() -> None:
     with Image.open("Tests/images/ani/aero_busy.ani") as im:
         assert im.size == (64, 64)
         assert im.info["frames"] == 18
@@ -26,7 +26,7 @@ def test_aero_busy():
             im.seek(18)
 
 
-def test_posy_busy():
+def test_posy_busy() -> None:
     with Image.open("Tests/images/ani/posy_busy.ani") as im:
         assert im.size == (96, 96)
         assert im.info["frames"] == 77
@@ -42,7 +42,7 @@ def test_posy_busy():
             im.seek(77)
 
 
-def test_stopwtch():
+def test_stopwtch() -> None:
     with Image.open("Tests/images/ani/stopwtch.ani") as im:
         assert im.size == (32, 32)
         assert im.info["frames"] == 8
@@ -67,7 +67,7 @@ def test_stopwtch():
             im.seek(8)
 
 
-def test_save():
+def test_save() -> None:
     directory_path = "Tests/images/ani/"
     filenames = [
         "aero_busy_0.png",

--- a/Tests/test_file_ani.py
+++ b/Tests/test_file_ani.py
@@ -10,7 +10,7 @@ from PIL import Image
 def test_aero_busy() -> None:
     with Image.open("Tests/images/ani/aero_busy.ani") as im:
         assert im.size == (64, 64)
-        assert im.info["frames"] == 18
+        assert im.n_frames == 18
 
         with Image.open("Tests/images/ani/aero_busy_0.png") as png:
             assert png.tobytes() == im.tobytes()
@@ -29,7 +29,7 @@ def test_aero_busy() -> None:
 def test_posy_busy() -> None:
     with Image.open("Tests/images/ani/posy_busy.ani") as im:
         assert im.size == (96, 96)
-        assert im.info["frames"] == 77
+        assert im.n_frames == 77
 
         with Image.open("Tests/images/ani/posy_busy_0.png") as png:
             assert png.tobytes() == im.tobytes()
@@ -45,7 +45,7 @@ def test_posy_busy() -> None:
 def test_stopwtch() -> None:
     with Image.open("Tests/images/ani/stopwtch.ani") as im:
         assert im.size == (32, 32)
-        assert im.info["frames"] == 8
+        assert im.n_frames == 8
 
         assert im.info["seq"][0] == 0
         assert im.info["seq"][2] == 0
@@ -132,7 +132,7 @@ def test_save() -> None:
         )
 
         with Image.open(output, formats=["ANI"]) as im:
-            assert im.info["frames"] == 6
+            assert im.n_frames == 6
             assert im.info["seq"] == [0, 2, 4, 1, 3, 5, 0, 1, 0, 1]
             assert im.info["rate"] == [1, 2, 3, 1, 2, 3, 1, 2, 3, 4]
             assert im.size == (32, 32)

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -18,7 +18,7 @@ def test_deerstalker() -> None:
         assert im.getpixel((16, 16)) == (84, 87, 86, 255)
 
 
-def test_posy_link():
+def test_posy_link() -> None:
     with Image.open("Tests/images/cur/posy_link.cur") as im:
         assert im.size == (128, 128)
         assert im.info["sizes"] == {(128, 128), (96, 96), (64, 64), (48, 48), (32, 32)}
@@ -34,7 +34,7 @@ def test_posy_link():
         assert im.getpixel((10, 10)) == (191, 191, 191, 255)
 
 
-def test_stopwtch():
+def test_stopwtch() -> None:
     with Image.open("Tests/images/cur/stopwtch.cur") as im:
         assert im.size == (32, 32)
         assert im.info["hotspots"] == [(16, 19)]
@@ -43,7 +43,7 @@ def test_stopwtch():
         assert im.getpixel((8, 16)) == (255, 0, 0, 255)
 
 
-def test_win98_arrow():
+def test_win98_arrow() -> None:
     with Image.open("Tests/images/cur/win98_arrow.cur") as im:
         assert im.size == (32, 32)
         assert im.info["hotspots"] == [(10, 10)]
@@ -68,7 +68,7 @@ def test_invalid_file() -> None:
             cur._open()
 
 
-def test_save_win98_arrow():
+def test_save_win98_arrow() -> None:
     with Image.open("Tests/images/cur/win98_arrow.png") as im:
         # save the data
         with BytesIO() as output:
@@ -80,20 +80,20 @@ def test_save_win98_arrow():
                 bitmap_format="bmp",
             )
 
-            with Image.open(output) as im2:
-                assert im.tobytes() == im2.tobytes()
+            with Image.open(output) as reloaded:
+                assert im.tobytes() == reloaded.tobytes()
 
         with BytesIO() as output:
             im.save(output, format="CUR")
 
             # check default save params
-            with Image.open(output) as im2:
-                assert im2.size == (32, 32)
-                assert im2.info["sizes"] == {(32, 32), (24, 24), (16, 16)}
-                assert im2.info["hotspots"] == [(0, 0), (0, 0), (0, 0)]
+            with Image.open(output) as reloaded:
+                assert reloaded.size == (32, 32)
+                assert reloaded.info["sizes"] == {(32, 32), (24, 24), (16, 16)}
+                assert reloaded.info["hotspots"] == [(0, 0), (0, 0), (0, 0)]
 
 
-def test_save_posy_link():
+def test_save_posy_link() -> None:
     sizes = [(128, 128), (96, 96), (64, 64), (48, 48), (32, 32)]
     hotspots = [(25, 7), (18, 5), (12, 3), (9, 2), (5, 1)]
 
@@ -110,18 +110,18 @@ def test_save_posy_link():
 
             # make sure saved output is readable
             # and sizes/hotspots are correct
-            with Image.open(output, formats=["CUR"]) as im2:
-                assert (128, 128) == im2.size
-                assert set(sizes) == im2.info["sizes"]
+            with Image.open(output, formats=["CUR"]) as reloaded:
+                assert (128, 128) == reloaded.size
+                assert set(sizes) == reloaded.info["sizes"]
 
         with BytesIO() as output:
             im.save(output, sizes=sizes[3:], hotspots=hotspots[3:], format="CUR")
 
             # make sure saved output is readable
             # and sizes/hotspots are correct
-            with Image.open(output, formats=["CUR"]) as im2:
-                assert (48, 48) == im2.size
-                assert set(sizes[3:]) == im2.info["sizes"]
+            with Image.open(output, formats=["CUR"]) as reloaded:
+                assert (48, 48) == reloaded.size
+                assert set(sizes[3:]) == reloaded.info["sizes"]
 
             # make sure error is thrown when size and hotspot len's
             # don't match

--- a/Tests/test_file_cur.py
+++ b/Tests/test_file_cur.py
@@ -21,7 +21,7 @@ def test_deerstalker() -> None:
 def test_posy_link():
     with Image.open("Tests/images/cur/posy_link.cur") as im:
         assert im.size == (128, 128)
-        assert im.info["sizes"] == [(128, 128), (96, 96), (64, 64), (48, 48), (32, 32)]
+        assert im.info["sizes"] == {(128, 128), (96, 96), (64, 64), (48, 48), (32, 32)}
         assert im.info["hotspots"] == [(25, 7), (18, 5), (12, 3), (9, 2), (5, 1)]
         # check some pixel colors
         assert im.getpixel((0, 0)) == (0, 0, 0, 0)
@@ -89,7 +89,7 @@ def test_save_win98_arrow():
             # check default save params
             with Image.open(output) as im2:
                 assert im2.size == (32, 32)
-                assert im2.info["sizes"] == [(32, 32), (24, 24), (16, 16)]
+                assert im2.info["sizes"] == {(32, 32), (24, 24), (16, 16)}
                 assert im2.info["hotspots"] == [(0, 0), (0, 0), (0, 0)]
 
 
@@ -112,7 +112,7 @@ def test_save_posy_link():
             # and sizes/hotspots are correct
             with Image.open(output, formats=["CUR"]) as im2:
                 assert (128, 128) == im2.size
-                assert sizes == im2.info["sizes"]
+                assert set(sizes) == im2.info["sizes"]
 
         with BytesIO() as output:
             im.save(output, sizes=sizes[3:], hotspots=hotspots[3:], format="CUR")
@@ -121,7 +121,7 @@ def test_save_posy_link():
             # and sizes/hotspots are correct
             with Image.open(output, formats=["CUR"]) as im2:
                 assert (48, 48) == im2.size
-                assert sizes[3:] == im2.info["sizes"]
+                assert set(sizes[3:]) == im2.info["sizes"]
 
             # make sure error is thrown when size and hotspot len's
             # don't match

--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -411,6 +411,7 @@ class AniImageFile(ImageFile.ImageFile):
 
         self.frame = 0
         self.seek(0)
+        self.load()
         self.size = self.im.size
 
     @property
@@ -438,7 +439,6 @@ class AniImageFile(ImageFile.ImageFile):
             raise EOFError(msg)
 
         self.frame = frame
-        self.load()
 
 
 Image.register_open(AniImageFile.format, AniImageFile, _accept)

--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -407,7 +407,7 @@ class AniImageFile(ImageFile.ImageFile):
         self.info["rate"] = self.ani.rate
 
         assert self.ani.anih is not None
-        self.info["frames"] = self.ani.anih["nFrames"]
+        self.n_frames = self.ani.anih["nFrames"]
 
         self.frame = 0
         self.seek(0)
@@ -434,9 +434,8 @@ class AniImageFile(ImageFile.ImageFile):
         return Image.Image.load(self)
 
     def seek(self, frame: int) -> None:
-        if frame > self.info["frames"] - 1 or frame < 0:
-            msg = "Frame index out of animation bounds"
-            raise EOFError(msg)
+        if not self._seek_check(frame):
+            return
 
         self.frame = frame
 

--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -424,12 +424,13 @@ class AniImageFile(ImageFile.ImageFile):
             raise ValueError(msg)
         self._size = value
 
-    def load(self) -> None:
+    def load(self) -> Image.core.PixelAccess | None:
         im = self.ani.frame(self.frame)
         self.info["sizes"] = im.info["sizes"]
         self.info["hotspots"] = im.info["hotspots"]
         self.im = im.im
         self._mode = im.mode
+        return Image.Image.load(self)
 
     def seek(self, frame: int) -> None:
         if frame > self.info["frames"] - 1 or frame < 0:

--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -410,7 +410,6 @@ class AniImageFile(ImageFile.ImageFile):
         self.info["frames"] = self.ani.anih["nFrames"]
 
         self.frame = 0
-        self._min_frame = 0
         self.seek(0)
         self.size = self.im.size
 

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -187,9 +187,6 @@ class CurFile(IcoImagePlugin.IcoFile):
 
         self.entry = sorted(self.entry, key=lambda x: x.square, reverse=True)
 
-    def sizes(self) -> list[tuple[int, int]]:
-        return [(h.width, h.height) for h in self.entry]
-
     def hotspots(self) -> list[tuple[int, int]]:
         return [(h.x_hotspot, h.y_hotspot) for h in self.entry]
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6606

CurFile currently redefines `sizes()` to return a list. This PR uses the inherited `sizes()` to return a set instead.