### PR TITLE
Removed alpha property

### DIFF
--- a/src/PIL/AniImagePlugin.py
+++ b/src/PIL/AniImagePlugin.py
@@ -69,8 +69,6 @@ def _save_frame(im: Image.Image, fp: BytesIO, info: dict[str, Any]) -> None:
                     image_io,
                     [ImageFile._Tile("raw", (0, 0) + size, 0, ("1", 0, -1))],
                 )
-            else:
-                frame.alpha = True
 
             frame.save(image_io, "dib")
         else:

--- a/src/PIL/BmpImagePlugin.py
+++ b/src/PIL/BmpImagePlugin.py
@@ -244,7 +244,7 @@ class BmpImageFile(ImageFile.ImageFile):
                 msg = "Unsupported BMP bitfields layout"
                 raise OSError(msg)
         elif file_info["compression"] == self.COMPRESSIONS["RAW"]:
-            if file_info["bits"] == 32 and (USE_RAW_ALPHA or hasattr(self, "alpha")):
+            if file_info["bits"] == 32 and USE_RAW_ALPHA:
                 raw_mode, self._mode = "BGRA", "RGBA"
         elif file_info["compression"] in (
             self.COMPRESSIONS["RLE8"],

--- a/src/PIL/CurImagePlugin.py
+++ b/src/PIL/CurImagePlugin.py
@@ -87,8 +87,6 @@ def _save(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
                     image_io,
                     [ImageFile._Tile("raw", (0, 0) + size, 0, ("1", 0, -1))],
                 )
-            else:
-                frame.alpha = True
 
             frame.save(image_io, "dib")
         else:


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6606

I don't think setting `frame.alpha = True` is necessary. From what I see, that line runs when saving ANI or CUR images, but is only checked when BMP opens a new image instance. So it would never be used?